### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in each version of the kubernetes cookboo
 
 ## Unreleased
 
+- resolved cookstyle error: resources/pod.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: resources/replication_controller.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: resources/service.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
 ## 1.0.2 - *2021-08-30*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/resources/pod.rb
+++ b/resources/pod.rb
@@ -17,6 +17,7 @@
 #
 
 provides :kube_pod
+unified_mode true
 
 # the name that will be used to identify the pod
 property :id, String, name_property: true

--- a/resources/replication_controller.rb
+++ b/resources/replication_controller.rb
@@ -17,6 +17,7 @@
 #
 
 provides :kube_replication_controller
+unified_mode true
 
 # the id that kubernetes will identify the controller with
 property :id, String, name_property: true

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -17,6 +17,7 @@
 #
 
 provides :kube_service
+unified_mode true
 
 # how kubernetes will identify the service
 property :id, String, name_property: true


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.25.6 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with resources/pod.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)

### Issues found and resolved with resources/replication_controller.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)

### Issues found and resolved with resources/service.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)